### PR TITLE
fix unmapListener's on IEventMap interface

### DIFF
--- a/src/robotlegs/bender/extensions/localEventMap/api/IEventMap.ts
+++ b/src/robotlegs/bender/extensions/localEventMap/api/IEventMap.ts
@@ -48,7 +48,7 @@ export interface IEventMap {
      * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>flash.events.Event</code>.
      * @param useCapture
      */
-    unmapListener(dispatcher: IEventDispatcher, type: string, listener: Function, thisObject?: any, eventClass?: Object, useCapture?: Boolean): void;
+    unmapListener(dispatcher: IEventDispatcher | EventTarget, type: string, listener: Function, thisObject?: any, eventClass?: Object, useCapture?: Boolean): void;
 
     /**
      * Removes all listeners registered through <code>mapListener</code>


### PR DESCRIPTION
It's possible to pass DOM elements on `mapListener` but it wasn't on `unmapListener`. This pull request fix this.